### PR TITLE
Migrate from pyautogen to ag2 Library

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ google.cloud.storage==2.14.0
 google.cloud.aiplatform==1.46.0
 pandas==2.1.4
 pyarrow==15.0.2
-pyautogen==0.2.14
+ag2==0.2.14
 st-star-rating==0.0.6
 streamlit==1.33.0
 requests==2.31.0

--- a/src/backend/requirements.txt
+++ b/src/backend/requirements.txt
@@ -7,7 +7,7 @@ google.cloud.aiplatform
 google.cloud.firestore
 pandas
 pyarrow
-pyautogen
+ag2
 beautifulsoup4
 requests
 urllib3


### PR DESCRIPTION
Hey there! This is AG2 👋

First of all, thank you for using pyautogen! We've seen you're using pyautogen, and we're here to help you migrate to ag2.

This pull request is designed to help update this codebase by smoothly transitioning from the `pyautogen` library to the new `ag2` library.

Why the change? `pyautogen` is being deprecated, and `ag2` is now the recommended successor for ongoing development. 

The good news is, **there is no syntax difference between pyautogen and ag2** – this migration primarily involves updating library imports and usage.

This update will ensure the project stays compatible with the latest tools and can benefit from all the improvements in the ag2 ecosystem.

Could you please take a moment to review and merge this at your earliest convenience? Your collaboration is much appreciated! Thank you!
